### PR TITLE
Feat/issue-07

### DIFF
--- a/src/main/java/com/thecommerce/thecommercetask/domain/user/controller/UserController.java
+++ b/src/main/java/com/thecommerce/thecommercetask/domain/user/controller/UserController.java
@@ -1,15 +1,13 @@
 package com.thecommerce.thecommercetask.domain.user.controller;
 
 import com.thecommerce.thecommercetask.domain.user.dto.request.JoinUserDto;
+import com.thecommerce.thecommercetask.domain.user.dto.response.UsersDto;
 import com.thecommerce.thecommercetask.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -27,4 +25,11 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
+    @GetMapping("/list")
+    public ResponseEntity<UsersDto> list(@RequestParam(name = "page", defaultValue = "0") int page,
+                                         @RequestParam(name = "size", defaultValue = "10") int size){
+
+        UsersDto dto = userService.list(page, size);
+        return ResponseEntity.status(HttpStatus.OK).body(dto);
+    }
 }

--- a/src/main/java/com/thecommerce/thecommercetask/domain/user/dto/response/UserDetailDto.java
+++ b/src/main/java/com/thecommerce/thecommercetask/domain/user/dto/response/UserDetailDto.java
@@ -1,0 +1,34 @@
+package com.thecommerce.thecommercetask.domain.user.dto.response;
+
+import com.thecommerce.thecommercetask.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserDetailDto {
+
+    private String username;
+    private String nickname;
+    private String fullName;
+    private String phoneNumber;
+    private String email;
+    private LocalDateTime createAt;
+
+    public static UserDetailDto of(User user){
+        return UserDetailDto.builder()
+                .username(user.getUsername())
+                .nickname(user.getNickname())
+                .fullName(user.getFullName())
+                .phoneNumber(user.getPhoneNumber())
+                .email(user.getEmail())
+                .createAt(user.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/thecommerce/thecommercetask/domain/user/dto/response/UsersDto.java
+++ b/src/main/java/com/thecommerce/thecommercetask/domain/user/dto/response/UsersDto.java
@@ -1,0 +1,40 @@
+package com.thecommerce.thecommercetask.domain.user.dto.response;
+
+import com.thecommerce.thecommercetask.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UsersDto {
+
+    private int totalPage;
+    private int page;
+    private int pageSize;
+    private long totalElements;
+    private boolean isLast;
+    private List<UserDetailDto> data;
+
+    public static UsersDto of(Page<User> users) {
+        List<UserDetailDto> userDetailDto = users.stream()
+                .map(UserDetailDto::of)
+                .collect(Collectors.toList());
+
+        return UsersDto.builder()
+                .totalPage(users.getTotalPages())
+                .page(users.getNumber())
+                .pageSize(users.getSize())
+                .totalElements(users.getTotalElements())
+                .isLast(users.isLast())
+                .data(userDetailDto)
+                .build();
+    }
+}

--- a/src/main/java/com/thecommerce/thecommercetask/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/thecommerce/thecommercetask/domain/user/repository/UserRepository.java
@@ -1,6 +1,8 @@
 package com.thecommerce.thecommercetask.domain.user.repository;
 
 import com.thecommerce.thecommercetask.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,4 +13,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     boolean existsByPhoneNumber(String phoneNumber);
+
+    Page<User> findAll(Pageable pageable);
 }

--- a/src/main/java/com/thecommerce/thecommercetask/domain/user/service/UserService.java
+++ b/src/main/java/com/thecommerce/thecommercetask/domain/user/service/UserService.java
@@ -1,9 +1,15 @@
 package com.thecommerce.thecommercetask.domain.user.service;
 
 import com.thecommerce.thecommercetask.domain.user.dto.request.JoinUserDto;
+import com.thecommerce.thecommercetask.domain.user.dto.response.UsersDto;
+import com.thecommerce.thecommercetask.domain.user.entity.User;
 import com.thecommerce.thecommercetask.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +25,15 @@ public class UserService {
     public void join(JoinUserDto dto) {
         checkDuplicate(dto);
         userRepository.save(dto.toEntity(dto));
+    }
+
+    public UsersDto list(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size,
+                Sort.by(Sort.Order.desc("createdAt"),
+                        Sort.Order.desc("fullName")));
+        Page<User> users = userRepository.findAll(pageable);
+
+        return UsersDto.of(users);
     }
 
     private void checkDuplicate(JoinUserDto dto) {


### PR DESCRIPTION
### ✨ 작업 내용
---

- [x] 회원 전체 조회
- [x] 페이징 처리 (totalPage, page, pageSize, totalElements, isLast)
- [x] 회원 조회를 sort를 createAt의 역순 정렬 (만약 createAt이 같다면 이름순으로)

### ✨ 참고 사항
---
1,
현재는 JPA를 활용하여 구현하였습니다.

```java
    Page<User> findAll(Pageable pageable);
```

추후 queryDSL로 변경할 수 있습니다.

2,
```java
        Pageable pageable = PageRequest.of(page, size,
                Sort.by(Sort.Order.desc("createdAt"),
                        Sort.Order.desc("fullName")));
```
Sort.by를 통해 역순 정렬하였습니다.

### ✏ Git Close
---

close #7 