### PR TITLE
Feat/issue-19

### DIFF
--- a/src/main/java/com/thecommerce/thecommercetask/domain/user/service/UserService.java
+++ b/src/main/java/com/thecommerce/thecommercetask/domain/user/service/UserService.java
@@ -9,7 +9,6 @@ import com.thecommerce.thecommercetask.domain.user.exception.DuplicatePhoneNumbe
 import com.thecommerce.thecommercetask.domain.user.exception.DuplicateUsernameException;
 import com.thecommerce.thecommercetask.domain.user.exception.NotFoundUsernameException;
 import com.thecommerce.thecommercetask.domain.user.repository.UserRepository;
-import com.thecommerce.thecommercetask.global.exception.error.GlobalErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -31,7 +30,8 @@ public class UserService {
 
     @Transactional
     public void join(JoinUserDto dto) {
-        checkDuplicate(dto);
+        checkDuplicateUsername(dto.getUsername());
+        checkDuplicateEmailAndPhoneNumber(dto.getEmail(), dto.getPhoneNumber());
         userRepository.save(dto.toEntity(dto));
     }
 
@@ -46,6 +46,7 @@ public class UserService {
 
     @Transactional
     public void update(String username, UpdateUserDto dto) {
+        checkDuplicateEmailAndPhoneNumber(dto.getEmail(), dto.getPhoneNumber());
         User user = findByUsername(username);
         user.updateUser(dto.getPassword(), dto.getNickname(), dto.getPhoneNumber(), dto.getEmail());
     }
@@ -55,16 +56,18 @@ public class UserService {
                 .orElseThrow(() -> new NotFoundUsernameException(NOT_FOUND_USERNAME_ERROR));
     }
 
-    private void checkDuplicate(JoinUserDto dto) {
-        if (userRepository.existsByUsername(dto.getUsername())){
+    private void checkDuplicateUsername(String username) {
+        if (userRepository.existsByUsername(username)){
             throw new DuplicateUsernameException(DUPLICATE_USERNAME_ERROR);
         }
+    }
 
-        if (userRepository.existsByEmail(dto.getEmail())){
+    private void checkDuplicateEmailAndPhoneNumber(String email, String phoneNumber) {
+        if (userRepository.existsByEmail(email)){
             throw new DuplicateEmailException(DUPLICATE_EMAIL_ERROR);
         }
 
-        if (userRepository.existsByPhoneNumber(dto.getPhoneNumber())){
+        if (userRepository.existsByPhoneNumber(phoneNumber)){
             throw new DuplicatePhoneNumberException(DUPLICATE_PHONE_NUMBER_ERROR);
         }
     }

--- a/src/main/java/com/thecommerce/thecommercetask/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/thecommerce/thecommercetask/global/exception/GlobalExceptionHandler.java
@@ -2,10 +2,9 @@ package com.thecommerce.thecommercetask.global.exception;
 
 import com.thecommerce.thecommercetask.global.exception.error.ErrorResponse;
 import com.thecommerce.thecommercetask.global.exception.error.GlobalError;
-import com.thecommerce.thecommercetask.global.exception.error.GlobalErrorCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
-import org.springframework.http.HttpStatus;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
@@ -13,17 +12,16 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
-import static com.sun.org.apache.xalan.internal.xsltc.compiler.sym.error;
 import static org.springframework.http.HttpStatus.*;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    private static final String CHECK_DUPLICATION = "회원Id, 이메일, 핸드폰 번호 중 하나가 중복상태입니다.";
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> exception(Exception ex) {
         log.error("{}", ex);
@@ -69,5 +67,16 @@ public class GlobalExceptionHandler {
                 .build();
 
         return ResponseEntity.status(BAD_REQUEST).body(response);
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ErrorResponse> handleValidationExceptions(DataIntegrityViolationException ex) {
+        ErrorResponse response = ErrorResponse.builder()
+                .code(CONFLICT.value())
+                .codeString(CONFLICT.name())
+                .message(CHECK_DUPLICATION)
+                .build();
+
+        return ResponseEntity.status(CONFLICT).body(response);
     }
 }


### PR DESCRIPTION
### ✨ 작업 내용
---

- [x] update 할 경우 이메일, 핸드폰 번호 중복 체크
- [x] 중복 체크 로직을 회원Id는 별도로 체크
- [x] globalExceptionHandler에 DataIntegrityViolationException에 대한 exceptionHandler 설정

### ✨ 참고 사항
---

```java
    private void checkDuplicateUsername(String username) {
        if (userRepository.existsByUsername(username)){
            throw new DuplicateUsernameException(DUPLICATE_USERNAME_ERROR);
        }
    }

    private void checkDuplicateEmailAndPhoneNumber(String email, String phoneNumber) {
        if (userRepository.existsByEmail(email)){
            throw new DuplicateEmailException(DUPLICATE_EMAIL_ERROR);
        }

        if (userRepository.existsByPhoneNumber(phoneNumber)){
            throw new DuplicatePhoneNumberException(DUPLICATE_PHONE_NUMBER_ERROR);
        }
    }
```

updateUser의 경우 email과 phoneNumber만 입력값으로 들어오기 때문에 email, phoneNumber만 따로 체크하는 메서드 생성하였습니다.
또한 username에 대한 체크하는 메서드를 생성하였습니다.

추후 리팩토링이 가능할 수 있어 GlobalExceptionHandler에서 DataIntegrityViolationException에 대한 exceptionHandler를 만들었습니다.

### ✏ Git Close
---

close #19 